### PR TITLE
タイトルとリンクをコピーした際にトースト形式で通知を表示

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,6 @@
+/**
+ * Scriptを実行するタブを現在開いているタブを指定
+ */
 chrome.action.onClicked.addListener((tab) => {
   chrome.scripting.executeScript({
     target: { tabId: tab.id },
@@ -5,6 +8,10 @@ chrome.action.onClicked.addListener((tab) => {
   });
 });
 
+/**
+ * 開いているタブのURLをコピーし、Markdown形式で保存する
+ * [{Web Title}](Web URL)
+ */
 function pickTitleAndLink() {
   const pageTitle = document.title;
   const url = document.URL;

--- a/background.js
+++ b/background.js
@@ -4,7 +4,7 @@
 chrome.action.onClicked.addListener((tab) => {
   chrome.scripting.executeScript({
     target: { tabId: tab.id },
-    function: copyTitleAndAlert,
+    function: pickTitleAndLink,
   });
 });
 
@@ -23,10 +23,33 @@ function pickTitleAndLink() {
   navigator.clipboard
     .writeText(markdownLink)
     .then(() => {
-      // コピー成功後にアラートを表示
-      alert("Title copied to clipboard");
+      // 通知用の要素を作成
+      const notification = document.createElement("div");
+      notification.style.position = "fixed";
+      notification.style.bottom = "10px";
+      notification.style.right = "10px";
+      notification.style.padding = "10px";
+      notification.style.backgroundColor = "black";
+      notification.style.color = "white";
+      notification.style.borderRadius = "5px";
+      notification.style.boxShadow = "0 0 10px rgba(0, 0, 0, 0.5)";
+      notification.style.zIndex = "10000";
+      notification.innerText = "タイトルとURLをコピーしました！";
+
+      // 通知クリックでタイトルとリンクを表示
+      notification.addEventListener("click", () => {
+        alert(`Copied Title: ${pageTitle}\nCopied link: ${url}`);
+      });
+
+      // ページに通知を追加
+      document.body.appendChild(notification);
+
+      // 5秒後に通知を自動的に削除
+      setTimeout(() => {
+        notification.remove();
+      }, 5000);
     })
     .catch((err) => {
-      console.error("Failed to copy title: ", err);
+      console.error("Failed to copy title and url: ", err);
     });
 }

--- a/background.js
+++ b/background.js
@@ -15,7 +15,6 @@ chrome.action.onClicked.addListener((tab) => {
 function pickTitleAndLink() {
   const pageTitle = document.title;
   const url = document.URL;
-
   // markdownのリンク形式として保存
   const markdownLink = `[${pageTitle}](${url})`;
 
@@ -29,7 +28,7 @@ function pickTitleAndLink() {
       notification.style.bottom = "10px";
       notification.style.right = "10px";
       notification.style.padding = "10px";
-      notification.style.backgroundColor = "black";
+      notification.style.backgroundColor = "#1f6feb";
       notification.style.color = "white";
       notification.style.borderRadius = "5px";
       notification.style.boxShadow = "0 0 10px rgba(0, 0, 0, 0.5)";


### PR DESCRIPTION
# 概要

<!-- 主題を詳細に記載してください -->

<!-- Issueがある場合はISSUEのURLを記載してください -->
<!-- - [Issue]() -->

表題通り、今まではwindowアラートで表示していたコピー成功通知をトーストのようにDOMを生成して表示する形式に変更しました

変更した意図は

- コピーした際にアラート表示のままではサイトを回遊できない
  - 本拡張機能はタイトルとURLのコピーの手軽さを追求しているため、コピーした際にwindowアラートを消す手間が入ってしまう現在の形式では逆効果になってしまうと考えました

## 動作確認

<!-- 下記以外で確認した動作がある場合はチェックリストを追加してください -->

- [x] ローカル環境で動作に問題がないことを確認した
- [x] 既存機能に関連するファイルを編集した場合、関連する動作に影響がないことを確認した
- [x] レビュー依頼時点でコンフリクトが発生していないことを確認した
- [x] レビュー依頼を行う際に、CI/CD がオールグリーンであることを確認した

![スクリーンショット 2024-10-14 160028](https://github.com/user-attachments/assets/69b71e1b-034b-47bf-8f37-4a9aab2e72a6)


<!-- 共有事項がある場合は記載してください -->
<!-- ## 共有事項 -->


